### PR TITLE
OpenMX 3.7でユーザーから読めないファイルがある

### DIFF
--- a/72_openmx/intel-mkl-mpich.sh
+++ b/72_openmx/intel-mkl-mpich.sh
@@ -27,6 +27,7 @@ echo "[make install]" | tee -a $LOG
 $SUDO_APPS mkdir -p $PREFIX/bin
 $SUDO_APPS make install DESTDIR=$PREFIX/bin | tee -a $LOG
 cd $BUILD_DIR/openmx-$OPENMX_VERSION
+$SUDO_APPS chmod -R a+r openmx*.pdf DFT_DATA13 work
 $SUDO_APPS cp -rp openmx*.pdf DFT_DATA13 work $PREFIX
 finish_info | tee -a $LOG
 

--- a/72_openmx/intel-mkl-openmpi.sh
+++ b/72_openmx/intel-mkl-openmpi.sh
@@ -27,6 +27,7 @@ echo "[make install]" | tee -a $LOG
 $SUDO_APPS mkdir -p $PREFIX/bin
 $SUDO_APPS make install DESTDIR=$PREFIX/bin | tee -a $LOG
 cd $BUILD_DIR/openmx-$OPENMX_VERSION
+$SUDO_APPS chmod -R a+r openmx*.pdf DFT_DATA13 work
 $SUDO_APPS cp -rp openmx*.pdf DFT_DATA13 work $PREFIX
 finish_info | tee -a $LOG
 

--- a/72_openmx/macos.sh
+++ b/72_openmx/macos.sh
@@ -27,6 +27,7 @@ echo "[make install]" | tee -a $LOG
 $SUDO_APPS mkdir -p $PREFIX/bin
 $SUDO_APPS make install DESTDIR=$PREFIX/bin | tee -a $LOG
 cd $BUILD_DIR/openmx-$OPENMX_VERSION
+$SUDO_APPS chmod -R a+r openmx*.pdf DFT_DATA13 work
 $SUDO_APPS cp -rp openmx*.pdf DFT_DATA13 work $PREFIX
 finish_info | tee -a $LOG
 


### PR DESCRIPTION
openmx/openmx-3.7.8-1/work/large_example/Mn12_148_F.dat のアクセス権が0640になっており、一般ユーザーから読めなくなっています。OpenMXのtarballの段階からアクセス権がおかしいです。

解決策として、インストール時に、chmod -R a+r ${INSTALL_DIRECTORY} を実行する、というものを提案します。
