### PR TITLE
Update 70_alps/macos.sh

### DIFF
--- a/70_alps/macos.sh
+++ b/70_alps/macos.sh
@@ -22,8 +22,8 @@ cd $BUILD_DIR/alps-build-$ALPS_VERSION
 start_info | tee -a $LOG
 echo "[cmake]" | tee -a $LOG
 check cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
-  -DCMAKE_C_COMPILER="/opt/local/bin/gcc" -DCMAKE_CXX_COMPILER="/opt/local/bin/g++" -DCMAKE_Fortran_COMPILER="/opt/local/bin/gfortran" \
-  -DPYTHON_INTERPRETER="/opt/local/bin/python2.7" \
+  -DCMAKE_C_COMPILER=`which gcc` -DCMAKE_CXX_COMPILER=`which g++` -DCMAKE_Fortran_COMPILER=`which gfortran` \
+  -DPYTHON_INTERPRETER=`which python2.7` \
   -DALPS_ENABLE_OPENMP=ON -DALPS_ENABLE_OPENMP_WORKER=ON \
   -DALPS_BUILD_FORTRAN=ON -DALPS_BUILD_TESTS=ON -DALPS_BUILD_PYTHON=ON \
   $BUILD_DIR/alps-$ALPS_VERSION | tee -a $LOG


### PR DESCRIPTION
gcc などのインストール先が Macports 決め打ちなのを修正
