### PR TITLE
Replace `source` with the dot (`.`) command.

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -8,7 +8,7 @@ set_prefix() {
   MALIVE_REPOSITORY_DEF="http://exa.phys.s.u-tokyo.ac.jp/archive/MateriApps/apt/pool"
 
   if [ -f "$HOME/.mainstaller" ]; then
-    source $HOME/.mainstaller
+    . $HOME/.mainstaller
   fi
 
   if [ -z "$PREFIX_TOOL" ]; then


### PR DESCRIPTION
Ubuntu系のshはbashではなくdashなので，`source`コマンドがない．
