### PR TITLE
copy UHF to binary directory

### DIFF
--- a/79_mVMC/gnu.sh
+++ b/79_mVMC/gnu.sh
@@ -34,6 +34,8 @@ echo "$SUDO_APPS cp src/vmc.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmc.out ${PREFIX}/bin
 echo "$SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin
+echo "$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin" | tee -a $LOG
+$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin
 
 echo "$SUDO_APPS cp -r sample ${PREFIX}" | tee -a $LOG
 $SUDO_APPS cp -r sample ${PREFIX}

--- a/79_mVMC/kei.sh
+++ b/79_mVMC/kei.sh
@@ -34,6 +34,8 @@ echo "$SUDO_APPS cp src/vmc.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmc.out ${PREFIX}/bin
 echo "$SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin
+echo "$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin" | tee -a $LOG
+$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin
 
 echo "$SUDO_APPS cp -r sample ${PREFIX}" | tee -a $LOG
 $SUDO_APPS cp -r sample ${PREFIX}

--- a/79_mVMC/mpich-gnu-mkl.sh
+++ b/79_mVMC/mpich-gnu-mkl.sh
@@ -34,6 +34,8 @@ echo "$SUDO_APPS cp src/vmc.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmc.out ${PREFIX}/bin
 echo "$SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin
+echo "$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin" | tee -a $LOG
+$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin
 
 echo "$SUDO_APPS cp -r sample ${PREFIX}" | tee -a $LOG
 $SUDO_APPS cp -r sample ${PREFIX}

--- a/79_mVMC/mpich-intel.sh
+++ b/79_mVMC/mpich-intel.sh
@@ -34,6 +34,8 @@ echo "$SUDO_APPS cp src/vmc.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmc.out ${PREFIX}/bin
 echo "$SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin
+echo "$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin" | tee -a $LOG
+$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin
 
 echo "$SUDO_APPS cp -r sample ${PREFIX}" | tee -a $LOG
 $SUDO_APPS cp -r sample ${PREFIX}

--- a/79_mVMC/openmpi-intel.sh
+++ b/79_mVMC/openmpi-intel.sh
@@ -34,6 +34,8 @@ echo "$SUDO_APPS cp src/vmc.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmc.out ${PREFIX}/bin
 echo "$SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin
+echo "$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin" | tee -a $LOG
+$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin
 
 echo "$SUDO_APPS cp -r sample ${PREFIX}" | tee -a $LOG
 $SUDO_APPS cp -r sample ${PREFIX}

--- a/79_mVMC/sekirei.sh
+++ b/79_mVMC/sekirei.sh
@@ -34,6 +34,8 @@ echo "$SUDO_APPS cp src/vmc.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmc.out ${PREFIX}/bin
 echo "$SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin" | tee -a $LOG
 $SUDO_APPS cp src/vmcdry.out ${PREFIX}/bin
+echo "$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin" | tee -a $LOG
+$SUDO_APPS cp src/ComplexUHF/src/UHF ${PREFIX}/bin
 
 echo "$SUDO_APPS cp -r sample ${PREFIX}" | tee -a $LOG
 $SUDO_APPS cp -r sample ${PREFIX}


### PR DESCRIPTION
copy `UHF`, which is auxiliary tool of `mVMC`, to bin directory