### PR TITLE
determine DLed filename explicitely

### DIFF
--- a/20_python/setup.sh
+++ b/20_python/setup.sh
@@ -30,7 +30,7 @@ if [ -d numpy-$NUMPY_VERSION ]; then :; else
   if [ -f $SOURCE_DIR/python/numpy-$NUMPY_VERSION.tar.gz ]; then
     check tar zxf $SOURCE_DIR/python/numpy-$NUMPY_VERSION.tar.gz
   else
-    check wget $WGET_OPTION https://github.com/numpy/numpy/releases/download/v$NUMPY_VERSION/numpy-$NUMPY_VERSION.tar.gz
+    check wget $WGET_OPTION https://github.com/numpy/numpy/releases/download/v$NUMPY_VERSION/numpy-$NUMPY_VERSION.tar.gz -O numpy-$NUMPY_VERSION.tar.gz
     check tar zxf numpy-$NUMPY_VERSION.tar.gz
   fi
 fi
@@ -40,7 +40,7 @@ if [ -d scipy-$SCIPY_VERSION ]; then :; else
   if [ -f $SOURCE_DIR/python/scipy-$SCIPY_VERSION.tar.gz ]; then
     check tar zxf $SOURCE_DIR/python/scipy-$SCIPY_VERSION.tar.gz
   else
-    check wget $WGET_OPTION https://github.com/scipy/scipy/releases/download/v$SCIPY_VERSION/scipy-$SCIPY_VERSION.tar.gz
+    check wget $WGET_OPTION https://github.com/scipy/scipy/releases/download/v$SCIPY_VERSION/scipy-$SCIPY_VERSION.tar.gz -O scipy-$SCIPY_VERSION.tar.gz
     check tar zxf scipy-$SCIPY_VERSION.tar.gz
   fi
 fi

--- a/21_python3/setup.sh
+++ b/21_python3/setup.sh
@@ -21,7 +21,7 @@ if [ -d numpy-$NUMPY_VERSION ]; then :; else
   if [ -f $SOURCE_DIR/python/numpy-$NUMPY_VERSION.tar.gz ]; then
     check tar zxf $SOURCE_DIR/python/numpy-$NUMPY_VERSION.tar.gz
   else
-    check wget $WGET_OPTION https://github.com/numpy/numpy/releases/download/v$NUMPY_VERSION/numpy-$NUMPY_VERSION.tar.gz
+    check wget $WGET_OPTION https://github.com/numpy/numpy/releases/download/v$NUMPY_VERSION/numpy-$NUMPY_VERSION.tar.gz -O numpy-$NUMPY_VERSION.tar.gz
     check tar zxf numpy-$NUMPY_VERSION.tar.gz
   fi
 fi
@@ -31,7 +31,7 @@ if [ -d scipy-$SCIPY_VERSION ]; then :; else
   if [ -f $SOURCE_DIR/python/scipy-$SCIPY_VERSION.tar.gz ]; then
     check tar zxf $SOURCE_DIR/python/scipy-$SCIPY_VERSION.tar.gz
   else
-    check wget $WGET_OPTION https://github.com/scipy/scipy/releases/download/v$SCIPY_VERSION/scipy-$SCIPY_VERSION.tar.gz
+    check wget $WGET_OPTION https://github.com/scipy/scipy/releases/download/v$SCIPY_VERSION/scipy-$SCIPY_VERSION.tar.gz -O scipy-$SCIPY_VERSION.tar.gz 
     check tar zxf scipy-$SCIPY_VERSION.tar.gz
   fi
 fi


### PR DESCRIPTION
GitHub のrelease のtarball はAWS においてあって、（多分ハッシュ値で作られている）ファイル名は長すぎてそのままではwget でダウンロードできないので、`-O` オプションでちゃんと名付けをしないといけません。
grep をかけた感じでは、他はちゃんと `-O` をつけているようでした。