### PR TITLE
run ci on ubuntu.2004

### DIFF
--- a/.github/scripts/lammps.sh
+++ b/.github/scripts/lammps.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+cd ${GITHUB_WORKSPACE}/apps/lammps
+MAKE_J=-j4 sh install.sh
+sh runtest.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   apps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: apt
         run: |


### PR DESCRIPTION
ubuntu-latest が ubuntu-22.04 を指すようになり、CI が落ちたので、一旦 20.04 を使うように変更。
22.04 についてはどこかのタイミングで対応します。

ついでに外部アクションのバージョンを上げました（警告メッセージが出ていたのが解決）