### PR TITLE
update GHA scripts

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -10,26 +10,26 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4.x
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: main
 
     - name: Checkout gh-pages
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: gh-pages
         path: gh-pages
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     # - name: Prepare LaTeX env
     #   run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,15 @@
 name: main
 
-on: [push]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 1,15 * *' # JST 9:00 on 1st and 15th every month
+
 
 jobs:
   apps:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -23,7 +28,7 @@ jobs:
       - name: apt
         run: |
           sudo apt-get update
-          sudo apt-get -y install openmpi-bin libopenmpi-dev libscalapack-openmpi-dev libfftw3-dev
+          sudo apt-get -y install libblas-dev liblapack-dev openmpi-bin libopenmpi-dev libscalapack-openmpi-dev libfftw3-dev
           if [ ${{ matrix.app }} = "respack" ]; then
             sudo apt-get -y install quantum-espresso
           fi
@@ -35,6 +40,6 @@ jobs:
 
       - name: setup
         run: sh setup/setup.sh
-      
+
       - name: test
         run: sh .github/scripts/test.sh ${{matrix.app}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
   apps:
     runs-on: ${{ matrix.os }}
 
+    continue-on-error: ${{ matrix.os == 'ubuntu-24.04' }}
+
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,11 @@ on:
 
 jobs:
   apps:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-24.04, ubuntu-22.04]
         app: [tenes, komega, hphi, mvmc, openmx, dsqss, espresso, respack, lammps, py2dmat, physbo]
       fail-fast: false
 


### PR DESCRIPTION
ubuntu-20.04はもう動かないので更新 (ドキュメントのCDの方)
自動テストは 22.04でしたが、ついでに24.04に更新……したのですが、結構落ちたのでひとまず22.04のままです。
（24.04でのテストもしていますが、全体のテスト結果には影響させないようにしてあります）

ついでに 1,15日に自動テストが流れるようにしてあります