### PR TITLE
fix_dylib.sh: 引数必須化（引数なし実行時の $HOME 以下 dylib 書き換えを防止）

### DIFF
--- a/scripts/fix_dylib.sh
+++ b/scripts/fix_dylib.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-DIR=$(cd $1 && pwd)
-LIBS=$(find $DIR -name "*.dylib" -o -name "*.so")
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 DIR"
+  exit 1
+fi
+DIR=$(cd "$1" && pwd) || exit 1
+
+LIBS=$(find "$DIR" -name "*.dylib" -o -name "*.so")
 for t in $LIBS; do
   echo "fixing install names for $t"
   install_name_tool -id $t $t


### PR DESCRIPTION
## 概要

Fixes #168

`scripts/fix_dylib.sh` は引数を省略すると `cd $1` が `cd`（引数なし）となって `$HOME` へ移動し、ホームディレクトリ配下の全 `.dylib`/`.so` の install name を `install_name_tool` で書き換えてしまう問題がありました。

- 引数が 1 個でなければ usage を表示して `exit 1`
- `cd "$1"` の失敗（ディレクトリ不存在）時も `exit 1`
- `$1` / `$DIR` をクォート

## 検証（macOS で実施）

| ケース | 修正前 | 修正後 |
|---|---|---|
| 引数なし | `$HOME` 以下を走査・書き換え | `Usage: ... DIR` を表示し exit 1 |
| 空ディレクトリ | 正常終了 | 何もせず exit 0 |
| 存在しないディレクトリ | `$PWD` 以下を走査（cd 失敗を無視） | エラー表示し exit 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)