### PR TITLE
cmake-find-package.sh: 作業ディレクトリを mktemp -d で作成

### DIFF
--- a/scripts/cmake-find-package-test.sh
+++ b/scripts/cmake-find-package-test.sh
@@ -8,8 +8,7 @@ if [ -z ${PACKAGE} ]; then
   exit 127
 fi
 
-WORK_DIR="${TMPDIR}find-package.$$"
-mkdir -p ${WORK_DIR}
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/find-package.XXXXXX") || exit 1
 
 cat << EOF > ${WORK_DIR}/CMakeLists.txt
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)

--- a/scripts/cmake-find-package-test.sh
+++ b/scripts/cmake-find-package-test.sh
@@ -11,7 +11,7 @@ fi
 WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/find-package.XXXXXX") || exit 1
 
 cat << EOF > ${WORK_DIR}/CMakeLists.txt
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(find)
 find_package(${PACKAGE})
 message(STATUS "find-package-result: \${${VERSION_VAR}}")

--- a/scripts/cmake-find-package.sh
+++ b/scripts/cmake-find-package.sh
@@ -17,8 +17,7 @@ if [ -z ${PACKAGE} ]; then
   exit 127
 fi
 
-WORK_DIR="${TMPDIR}find-package.$$"
-mkdir -p ${WORK_DIR}
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/find-package.XXXXXX") || exit 1
 
 cat << EOF > ${WORK_DIR}/CMakeLists.txt
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)


### PR DESCRIPTION
## 概要

Fixes #171

`WORK_DIR="${TMPDIR}find-package.$$"` には以下の問題がありました。

- `TMPDIR` 未設定（Linux で一般的）だと相対パスになり、**カレントディレクトリに作業ディレクトリを作成して最後に `rm -rf`** していた
- `TMPDIR` 末尾スラッシュ（macOS の慣習）を仮定
- `$$` による予測可能な名前

`WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/find-package.XXXXXX") || exit 1` に変更しました。

## 検証（macOS で実施）

- `TMPDIR` あり/なし（`env -u TMPDIR`）の両方で `sh scripts/cmake-find-package.sh ZLIB ZLIB_VERSION_STRING` が `1.2.12` を返し exit 0
- 実行後、カレントディレクトリと /tmp に残骸ディレクトリが残らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)