### PR TITLE
macOS CI スモークテストの追加（gcc-wrapper + komega）

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,15 @@ jobs:
           sh install.sh
           sh link.sh
           . $HOME/materiapps/env.sh
+          # the wrapper, not a compiler that happens to be on the runner
+          # PATH, must resolve first
+          for prog in gcc gfortran; do
+            p=$(command -v $prog)
+            case "$p" in
+              $HOME/materiapps/gcc-wrapper/*) echo "$prog -> $p" ;;
+              *) echo "Error: $prog resolves to $p, not to the gcc-wrapper"; exit 1 ;;
+            esac
+          done
           gcc --version
           gfortran --version
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,47 @@
+name: macos
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 1,15 * *' # JST 9:00 on 1st and 15th every month
+
+jobs:
+  smoke:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: brew
+        run: |
+          # wget is used by all download.sh; open-mpi pulls in Homebrew gcc,
+          # which gcc-wrapper requires
+          brew install wget open-mpi
+
+      - name: configure
+        run: echo "MA_ROOT=$HOME/materiapps" > $HOME/.mainstaller
+
+      - name: setup
+        run: sh setup/setup.sh
+
+      - name: gcc-wrapper
+        run: |
+          cd tools/gcc-wrapper
+          sh install.sh
+          sh link.sh
+          . $HOME/materiapps/env.sh
+          gcc --version
+          gfortran --version
+
+      - name: komega
+        run: |
+          cd apps/komega
+          sh install.sh
+          sh link.sh
+
+      - name: komega test
+        run: |
+          cd apps/komega
+          sh runtest.sh


### PR DESCRIPTION
## 概要

Fixes #180

`macos-14`（Apple Silicon）ランナーで setup → `tools/gcc-wrapper`（install/link + gcc/gfortran 動作確認）→ `apps/komega`（install/link/runtest）を実行する workflow `.github/workflows/macos.yml` を追加します。トリガーは Ubuntu CI と同じ push / pull_request / 月 2 回の cron。

macOS 固有の要素（Homebrew GCC の検出、Xcode SDK workaround、fix_dylib 系）はこれまで CI カバレッジがゼロで、直近の SDK 26 対応などはローカル検証頼みでした。まず最小のスモークテストを入れ、対象アプリは今後拡大する想定です。

## 検証

CI と同一の手順をローカルの macOS（Apple Silicon, Homebrew）で一時 `MA_ROOT` を使って通しで実行し、komega の runtest が **Test Passed** になることを確認済み。その際の知見を workflow に反映しています:

- macOS ランナーには `wget` が無い → `brew install wget`（全 download.sh が wget 依存）
- `open-mpi` を入れると依存で Homebrew gcc も入り、gcc-wrapper の要求を満たす

この PR 自体の push で workflow が実行されるので、Actions の結果もあわせて確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)