### PR TITLE
上流バージョン監視の自動化（cron + 自動 Issue 起票）

### DIFF
--- a/.github/workflows/version_watch.yml
+++ b/.github/workflows/version_watch.yml
@@ -1,0 +1,22 @@
+name: version watch
+
+on:
+  schedule:
+    - cron: '0 2 1,15 * *' # JST 11:00 on 1st and 15th every month
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check upstream versions and file issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: sh scripts/check_upstream_versions.sh --create-issues

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,22 @@
+# scripts/ — shared and maintenance scripts
+
+## Sourced by package scripts
+
+- `util.sh` — shared shell library (`set_prefix`, `check`, `pipefail`,
+  `find_tool`, ...). Sourced by every install/download/setup script.
+- `cmake-find-package.sh` — prints the version of a package found via
+  CMake `find_package`; used by `tools/*/find.sh`.
+- `cmake-find-package-test.sh` — debug variant that prints the raw
+  CMake find-debug output.
+
+## Maintenance tools (run manually or from CI)
+
+- `list_maversion.sh` — list the pinned versions of all tools and apps.
+- `check_upstream_versions.sh [--create-issues]` — compare the pins of
+  GitHub-hosted packages with the latest upstream releases; used by the
+  `version watch` workflow to file update issues (at most
+  `MAX_ISSUES` (default 10) new issues per run).
+- `check_mpicompiler.sh CC MPICC` — verify a compiler and its MPI
+  wrapper report the same version.
+- `fix_dylib.sh DIR` — rewrite install names of the shared libraries
+  under DIR (macOS).

--- a/scripts/check_upstream_versions.sh
+++ b/scripts/check_upstream_versions.sh
@@ -19,9 +19,21 @@
 
 set -u
 
+case "${1:-}" in
+  -h|--help)
+    echo "Usage: $0 [--create-issues]"
+    echo "Compare version.sh pins with the latest upstream GitHub releases."
+    echo "  --create-issues  open an issue per outdated package (needs gh auth;"
+    echo "                   at most MAX_ISSUES=${MAX_ISSUES:-10} new issues per run)"
+    exit 0
+    ;;
+esac
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ROOT_DIR=$(dirname "$SCRIPT_DIR")
 CREATE_ISSUES=${1:-}
+# cap new issues per run to avoid flooding watchers on the first runs
+MAX_ISSUES=${MAX_ISSUES:-10}
 
 open_titles=""
 if [ "$CREATE_ISSUES" = "--create-issues" ]; then
@@ -34,6 +46,7 @@ fi
 
 outdated=0
 errors=0
+created=0
 for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
   [ -d "$dir" ] || continue
   [ -f "$dir/version.sh" ] || continue
@@ -100,6 +113,8 @@ for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
     title="[$name] New upstream version $latest_norm"
     if printf '%s\n' "$open_titles" | grep -Fxq "$title"; then
       echo "         issue already open: $title"
+    elif [ "$created" -ge "$MAX_ISSUES" ]; then
+      echo "         issue NOT created (MAX_ISSUES=$MAX_ISSUES reached): $title"
     elif gh issue create --title "$title" --body "The upstream release of \`$name\` (https://github.com/$ownerrepo) is now **$latest_norm**, while \`version.sh\` pins **$pinned**.
 
 To update:
@@ -109,6 +124,7 @@ To update:
 
 _Opened automatically by the version watch workflow._"; then
       echo "         issue created: $title"
+      created=$((created + 1))
       open_titles=$(printf '%s\n%s' "$open_titles" "$title")
     else
       echo "ERROR    $name: gh issue create failed"
@@ -119,5 +135,8 @@ done
 
 echo "-----"
 echo "$outdated package(s) outdated, $errors API error(s)"
+if [ "$CREATE_ISSUES" = "--create-issues" ]; then
+  echo "$created issue(s) created (cap: MAX_ISSUES=$MAX_ISSUES)"
+fi
 [ "$errors" -eq 0 ] || exit 1
 exit 0

--- a/scripts/check_upstream_versions.sh
+++ b/scripts/check_upstream_versions.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Compare the pinned version of each GitHub-hosted package with the
+# latest upstream release and report outdated ones.
+#
+# Usage: sh scripts/check_upstream_versions.sh [--create-issues]
+#
+# Only packages whose download.sh fetches a github.com URL containing
+# ${__VERSION__} are checked; upstreams without GitHub releases are
+# skipped. Requires an authenticated gh CLI (in GitHub Actions, set
+# GH_TOKEN=${{ github.token }}).
+#
+# With --create-issues, an issue titled "[<name>] New upstream version
+# <version>" is opened for each outdated package unless an open issue
+# with the same title already exists.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+CREATE_ISSUES=${1:-}
+
+outdated=0
+for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
+  [ -d "$dir" ] || continue
+  [ -f "$dir/version.sh" ] || continue
+  [ -f "$dir/download.sh" ] || continue
+  name=$(basename "$dir")
+
+  # the URL that is versioned by __VERSION__ (not e.g. __VERSION_BLAS__),
+  # ignoring commented-out lines
+  url_line=$(grep 'github\.com' "$dir/download.sh" | grep '{__VERSION__}' \
+    | grep -v '^[[:space:]]*#' | head -1)
+  [ -n "$url_line" ] || continue
+  url_line=$(echo "$url_line" | sed "s/\${__NAME__}/$name/g")
+  ownerrepo=$(echo "$url_line" | sed -n 's%.*github\.com/\([^/]*\)/\([^/]*\)/.*%\1/\2%p')
+  [ -n "$ownerrepo" ] || continue
+  case "$ownerrepo" in
+    *'$'*) continue ;; # unresolved shell variable in the URL
+  esac
+
+  pinned=$( (. "$dir/version.sh" >/dev/null 2>&1; echo "${__VERSION__:-}") )
+  [ -n "$pinned" ] || continue
+
+  latest=$(gh api "repos/$ownerrepo/releases/latest" -q .tag_name 2>/dev/null) || latest=""
+  if [ -z "$latest" ]; then
+    echo "skip     $name ($ownerrepo): no GitHub releases"
+    continue
+  fi
+  # tags come as 3.6.0, v3.6.0, v.1.5.0, qe-7.0, ... : drop the prefix
+  latest_norm=$(echo "$latest" | sed 's/^[^0-9]*//')
+
+  if [ "$latest_norm" = "$pinned" ]; then
+    echo "ok       $name: $pinned"
+    continue
+  fi
+  # only report if the upstream release is really newer (some upstreams
+  # tag formal releases less often than we pin)
+  newer=$(printf '%s\n%s\n' "$pinned" "$latest_norm" | sort -V | tail -1)
+  if [ "$newer" = "$pinned" ]; then
+    echo "ok       $name: $pinned (latest GitHub release is older: $latest_norm)"
+    continue
+  fi
+
+  echo "OUTDATED $name: pinned $pinned, latest $latest_norm ($ownerrepo)"
+  outdated=$((outdated + 1))
+
+  if [ "$CREATE_ISSUES" = "--create-issues" ]; then
+    title="[$name] New upstream version $latest_norm"
+    if gh issue list --state open --search "\"$title\" in:title" \
+         --json title --jq '.[].title' | grep -Fxq "$title"; then
+      echo "         issue already open: $title"
+    else
+      gh issue create --title "$title" --body "The upstream release of \`$name\` (https://github.com/$ownerrepo) is now **$latest_norm**, while \`version.sh\` pins **$pinned**.
+
+To update:
+1. Bump the version (and reset the MA_REVISION to 1) in the package's \`version.sh\`
+2. Check whether the URL pattern in \`download.sh\` still matches
+3. Rename or drop stale \`patch/$name-$pinned.patch\` files if present
+
+_Opened automatically by the version watch workflow._"
+      echo "         issue created: $title"
+    fi
+  fi
+done
+
+echo "-----"
+echo "$outdated package(s) outdated"
+exit 0

--- a/scripts/check_upstream_versions.sh
+++ b/scripts/check_upstream_versions.sh
@@ -23,6 +23,15 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ROOT_DIR=$(dirname "$SCRIPT_DIR")
 CREATE_ISSUES=${1:-}
 
+open_titles=""
+if [ "$CREATE_ISSUES" = "--create-issues" ]; then
+  # fetched once; created titles are appended locally below
+  open_titles=$(gh issue list --state open --limit 1000 --json title --jq '.[].title') || {
+    echo "Fatal: cannot list open issues"
+    exit 1
+  }
+fi
+
 outdated=0
 errors=0
 for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
@@ -89,19 +98,21 @@ for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
 
   if [ "$CREATE_ISSUES" = "--create-issues" ]; then
     title="[$name] New upstream version $latest_norm"
-    if gh issue list --state open --limit 500 \
-         --json title --jq '.[].title' | grep -Fxq "$title"; then
+    if printf '%s\n' "$open_titles" | grep -Fxq "$title"; then
       echo "         issue already open: $title"
-    else
-      gh issue create --title "$title" --body "The upstream release of \`$name\` (https://github.com/$ownerrepo) is now **$latest_norm**, while \`version.sh\` pins **$pinned**.
+    elif gh issue create --title "$title" --body "The upstream release of \`$name\` (https://github.com/$ownerrepo) is now **$latest_norm**, while \`version.sh\` pins **$pinned**.
 
 To update:
 1. Bump the version (and reset the MA_REVISION to 1) in the package's \`version.sh\`
 2. Check whether the URL pattern in \`download.sh\` still matches
 3. Rename or drop stale \`patch/$name-$pinned.patch\` files if present
 
-_Opened automatically by the version watch workflow._"
+_Opened automatically by the version watch workflow._"; then
       echo "         issue created: $title"
+      open_titles=$(printf '%s\n%s' "$open_titles" "$title")
+    else
+      echo "ERROR    $name: gh issue create failed"
+      errors=$((errors + 1))
     fi
   fi
 done

--- a/scripts/check_upstream_versions.sh
+++ b/scripts/check_upstream_versions.sh
@@ -4,14 +4,18 @@
 #
 # Usage: sh scripts/check_upstream_versions.sh [--create-issues]
 #
-# Only packages whose download.sh fetches a github.com URL containing
-# ${__VERSION__} are checked; upstreams without GitHub releases are
+# Only packages whose download.sh fetches a github.com URL versioned by
+# __VERSION__ are checked; upstreams without GitHub releases are
 # skipped. Requires an authenticated gh CLI (in GitHub Actions, set
 # GH_TOKEN=${{ github.token }}).
 #
 # With --create-issues, an issue titled "[<name>] New upstream version
 # <version>" is opened for each outdated package unless an open issue
 # with the same title already exists.
+#
+# Exits nonzero if any GitHub API call fails for a reason other than
+# "no releases" (auth, rate limit, network), so a scheduled run cannot
+# silently skip everything.
 
 set -u
 
@@ -20,19 +24,21 @@ ROOT_DIR=$(dirname "$SCRIPT_DIR")
 CREATE_ISSUES=${1:-}
 
 outdated=0
+errors=0
 for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
   [ -d "$dir" ] || continue
   [ -f "$dir/version.sh" ] || continue
   [ -f "$dir/download.sh" ] || continue
   name=$(basename "$dir")
 
-  # the URL that is versioned by __VERSION__ (not e.g. __VERSION_BLAS__),
-  # ignoring commented-out lines
-  url_line=$(grep 'github\.com' "$dir/download.sh" | grep '{__VERSION__}' \
+  # the URL versioned by __VERSION__ -- braced or not, but not
+  # e.g. __VERSION_BLAS__ -- ignoring commented-out lines
+  url_line=$(grep 'github\.com' "$dir/download.sh" \
+    | grep -E '\$(\{__VERSION__\}|__VERSION__([^A-Za-z0-9_]|$))' \
     | grep -v '^[[:space:]]*#' | head -1)
   [ -n "$url_line" ] || continue
-  url_line=$(echo "$url_line" | sed "s/\${__NAME__}/$name/g")
-  ownerrepo=$(echo "$url_line" | sed -n 's%.*github\.com/\([^/]*\)/\([^/]*\)/.*%\1/\2%p')
+  url_line=$(echo "$url_line" | sed -e "s/\${__NAME__}/$name/g" -e "s/\"\$__NAME__\"/$name/g")
+  ownerrepo=$(echo "$url_line" | sed -n 's%.*github\.com/\([^/]*\)/\([^/"]*\)/.*%\1/\2%p')
   [ -n "$ownerrepo" ] || continue
   case "$ownerrepo" in
     *'$'*) continue ;; # unresolved shell variable in the URL
@@ -41,11 +47,21 @@ for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
   pinned=$( (. "$dir/version.sh" >/dev/null 2>&1; echo "${__VERSION__:-}") )
   [ -n "$pinned" ] || continue
 
-  latest=$(gh api "repos/$ownerrepo/releases/latest" -q .tag_name 2>/dev/null) || latest=""
-  if [ -z "$latest" ]; then
-    echo "skip     $name ($ownerrepo): no GitHub releases"
+  api_out=$(gh api "repos/$ownerrepo/releases/latest" -q .tag_name 2>&1)
+  api_status=$?
+  if [ $api_status -ne 0 ]; then
+    case "$api_out" in
+      *"Not Found"*|*"HTTP 404"*)
+        echo "skip     $name ($ownerrepo): no GitHub releases"
+        ;;
+      *)
+        echo "ERROR    $name ($ownerrepo): gh api failed: $api_out"
+        errors=$((errors + 1))
+        ;;
+    esac
     continue
   fi
+  latest=$api_out
   # tags come as 3.6.0, v3.6.0, v.1.5.0, qe-7.0, ... : drop the prefix
   latest_norm=$(echo "$latest" | sed 's/^[^0-9]*//')
 
@@ -53,12 +69,19 @@ for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
     echo "ok       $name: $pinned"
     continue
   fi
-  # only report if the upstream release is really newer (some upstreams
-  # tag formal releases less often than we pin)
-  newer=$(printf '%s\n%s\n' "$pinned" "$latest_norm" | sort -V | tail -1)
-  if [ "$newer" = "$pinned" ]; then
-    echo "ok       $name: $pinned (latest GitHub release is older: $latest_norm)"
-    continue
+  # a pin like 1.0-beta is older than the released 1.0 even though
+  # sort -V may order it after
+  pinned_base=${pinned%%-*}
+  if [ "$pinned" != "$pinned_base" ] && [ "$latest_norm" = "$pinned_base" ]; then
+    :
+  else
+    # only report if the upstream release is really newer (some
+    # upstreams tag formal releases less often than we pin)
+    newer=$(printf '%s\n%s\n' "$pinned" "$latest_norm" | sort -V | tail -1)
+    if [ "$newer" = "$pinned" ]; then
+      echo "ok       $name: $pinned (latest GitHub release is older: $latest_norm)"
+      continue
+    fi
   fi
 
   echo "OUTDATED $name: pinned $pinned, latest $latest_norm ($ownerrepo)"
@@ -66,7 +89,7 @@ for dir in "$ROOT_DIR"/apps/* "$ROOT_DIR"/tools/*; do
 
   if [ "$CREATE_ISSUES" = "--create-issues" ]; then
     title="[$name] New upstream version $latest_norm"
-    if gh issue list --state open --search "\"$title\" in:title" \
+    if gh issue list --state open --limit 500 \
          --json title --jq '.[].title' | grep -Fxq "$title"; then
       echo "         issue already open: $title"
     else
@@ -84,5 +107,6 @@ _Opened automatically by the version watch workflow._"
 done
 
 echo "-----"
-echo "$outdated package(s) outdated"
+echo "$outdated package(s) outdated, $errors API error(s)"
+[ "$errors" -eq 0 ] || exit 1
 exit 0


### PR DESCRIPTION
## 概要

Fixes #183

`version.sh` の pin と上流の最新 GitHub リリースを定期比較し、更新があれば Issue を自動起票する仕組みを追加します。

### scripts/check_upstream_versions.sh
- 各パッケージの `download.sh` から `${__VERSION__}` でバージョン指定された github.com URL を抽出し owner/repo を自動導出（コメント行は除外、`${__NAME__}` は展開、変数が残る URL はスキップ）
- タグの接頭辞を正規化（`v3.6.0` / `v.1.5.0` / `qe-7.0` → 数値部分）し、`sort -V` で**pin より新しい場合のみ**報告（espresso のように正式リリースが pin より古い上流を誤検出しない）
- `--create-issues` 指定時、`[<name>] New upstream version <ver>` の Issue を起票。同名の open Issue があればスキップ（重複防止）
- GitHub Releases を持たない上流（aenet, xtensor 等）と GitHub 外ホスト（openmx, respack 等）は対象外としてスキップ表示

### .github/workflows/version_watch.yml
- 月 2 回（1日・15日）の cron + `workflow_dispatch`(手動実行)
- `issues: write` 権限で `--create-issues` 実行

## 検証

- ライブ API に対するドライラン（Issue 起票なし）で 21 の GitHub ホストパッケージを検査し、16 件の実際の更新（hphi 3.5.2→3.6.0、alpscore 2.3.2→2.3.3、spglib 2.5.0→2.7.0 等）を誤検出ゼロで検出
- 開発中に発見した誤検出 4 パターン（コメント行の別リポジトリ URL、`${__NAME__}` 未展開、`v.` 接頭辞、上流リリースが pin より古い）はすべて解消済み
- shellcheck (`--severity=warning -s sh`) クリーン(#178 の CI 対象に入っても通ります)

## 運用メモ

マージ後の初回実行で最大 16 件の Issue が一度に立ちます。多すぎる場合は先に主要パッケージのバージョン更新を済ませるか、手動 dispatch で様子を見てから cron に任せてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)