### PR TITLE
~/.mainstaller の設定サンプルを同梱 (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Install script collection for MateriApps Software
 
 1. Specify install direcoty
     - `echo MA_ROOT=$HOME/materiapps > ~/.mainstaller`
+    - See [`dot.mainstaller.example`](dot.mainstaller.example) for all configurable variables (`MA_ROOT`, `BUILD_DIR`, `SOURCE_DIR`, ...); `sh check_prefix.sh` prints the directories currently in effect.
 2. Setup
     - `(cd setup; sh setup.sh)`
 3. Install application(s) you desire (e.g., HPhi)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Install script collection for MateriApps Software
 
 # Quick Usage
 
-1. Specify install direcoty
+1. Specify install directory
     - `echo MA_ROOT=$HOME/materiapps > ~/.mainstaller`
-    - See [`dot.mainstaller.example`](dot.mainstaller.example) for all configurable variables (`MA_ROOT`, `BUILD_DIR`, `SOURCE_DIR`, ...); `sh check_prefix.sh` prints the directories currently in effect.
+    - See [`dot.mainstaller.example`](dot.mainstaller.example) in the repository root for all configurable variables (`MA_ROOT`, `BUILD_DIR`, `SOURCE_DIR`, ...); `sh check_prefix.sh` prints the directories currently in effect.
 2. Setup
     - `(cd setup; sh setup.sh)`
 3. Install application(s) you desire (e.g., HPhi)

--- a/docs/sphinx/en/source/how_to_use/index.rst
+++ b/docs/sphinx/en/source/how_to_use/index.rst
@@ -146,6 +146,7 @@ Setup
 
    - If this file does not exist, the software will be installed under ``$ HOME materiapps``
    - (*) Note that the actual installation location uses the contents of the ``.mainstaller`` file at the time of the installation work described below.
+   - A ready-to-copy template with all variables is provided as ``dot.mainstaller.example`` at the top of the repository (``cp dot.mainstaller.example ~/.mainstaller``). Run ``sh check_prefix.sh`` to print the directories currently in effect.
 
 Install
 ============

--- a/docs/sphinx/ja/source/how_to_use/index.rst
+++ b/docs/sphinx/ja/source/how_to_use/index.rst
@@ -141,6 +141,7 @@
 
   - このファイルがない場合は ``$HOME/materiapps`` の下にソフトウェアがインストールされる
   - (注) 実際のインストール場所は、 ``setup.sh`` を実行した時の情報ではなく、以降で説明するインストール作業を行った時点での ``.mainstaller`` ファイルの内容が用いられる.
+  - 全変数を記載したひな形 ``dot.mainstaller.example`` をリポジトリ直下に用意している（ ``cp dot.mainstaller.example ~/.mainstaller`` でコピーして編集する）。 ``sh check_prefix.sh`` を実行すると現在有効なディレクトリが表示される。
 
 インストール
 ============

--- a/dot.mainstaller.example
+++ b/dot.mainstaller.example
@@ -1,0 +1,30 @@
+# Example configuration for MateriApps Installer.
+#
+# Copy this file to ~/.mainstaller and edit the values:
+#     cp dot.mainstaller.example ~/.mainstaller
+#
+# This file is sourced as a POSIX shell script, so:
+#   - put NO spaces around '='   (MA_ROOT=... , not MA_ROOT = ...)
+#   - none of the directory paths may contain whitespace
+#
+# Every variable is optional; the default (shown after '=' below) is
+# used when a variable is unset. Run `sh check_prefix.sh` to print the
+# directories that are actually in effect.
+
+# Directory where the software is installed.
+MA_ROOT=$HOME/materiapps
+
+# Working directory used while building (can be deleted afterwards).
+BUILD_DIR=$HOME/build
+
+# Directory where downloaded source archives are cached.
+SOURCE_DIR=$HOME/source
+
+# Base URL of the MateriApps LIVE! Debian repository. Most users never
+# need this; it is only used by a few Debian-packaged applications.
+# MALIVE_REPOSITORY=https://download.sourceforge.net/project/materiappslive/Debian/archive/buster
+
+# You can keep several configuration files (e.g. one per machine) and
+# select one at run time with the MAINSTALLER_CONFIG environment
+# variable instead of ~/.mainstaller:
+#     MAINSTALLER_CONFIG=$HOME/.mainstaller.ohtaka sh install.sh

--- a/dot.mainstaller.example
+++ b/dot.mainstaller.example
@@ -7,9 +7,9 @@
 #   - put NO spaces around '='   (MA_ROOT=... , not MA_ROOT = ...)
 #   - none of the directory paths may contain whitespace
 #
-# Every variable is optional; the default (shown after '=' below) is
-# used when a variable is unset. Run `sh check_prefix.sh` to print the
-# directories that are actually in effect.
+# The three directory variables below are optional; the value shown
+# after '=' is the built-in default used when the variable is unset.
+# Run `sh check_prefix.sh` to print the directories actually in effect.
 
 # Directory where the software is installed.
 MA_ROOT=$HOME/materiapps
@@ -20,8 +20,10 @@ BUILD_DIR=$HOME/build
 # Directory where downloaded source archives are cached.
 SOURCE_DIR=$HOME/source
 
-# Base URL of the MateriApps LIVE! Debian repository. Most users never
-# need this; it is only used by a few Debian-packaged applications.
+# Optional: override the base URL of the MateriApps LIVE! Debian
+# repository (used only by a few Debian-packaged applications). Leave
+# this commented out to keep the built-in default; most users never
+# need it.
 # MALIVE_REPOSITORY=https://download.sourceforge.net/project/materiappslive/Debian/archive/buster
 
 # You can keep several configuration files (e.g. one per machine) and


### PR DESCRIPTION
## 概要

Fixes #181

`~/.mainstaller` の設定サンプル `dot.mainstaller.example` をリポジトリ直下に追加し、README と how_to_use マニュアル（en/ja）から参照します。

- `dot.mainstaller.example`: `MA_ROOT` / `BUILD_DIR` / `SOURCE_DIR` を既定値付きで例示。`set_prefix` が読む残りの変数（`MALIVE_REPOSITORY`、`MAINSTALLER_CONFIG` による設定ファイル切替）もコメントで記載。`=` の前後に空白を置かない・パスに空白を含めない、という制約も明記
- README / docs から参照し、`sh check_prefix.sh` で現在の解決結果を確認できることも案内

## 検証

- `sh -n dot.mainstaller.example`（構文チェック）通過
- サンプルを一時 `~/.mainstaller` としてコピー → `MAINSTALLER_CONFIG` 経由で `set_prefix` に読ませ、`print_prefix` が期待どおり `MA_ROOT`/`BUILD_DIR`/`SOURCE_DIR` を解決することを確認

## 補足（マージ順）

README と how_to_use (en/ja) は #178・#186 も同じセクションを編集しているため軽微な競合が出る可能性があります（いずれも自明に解消できます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)