### PR TITLE
docs: macOS チュートリアルを gcc-wrapper 方式に刷新 (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Install script collection for MateriApps Software
     - `source $HOME/materiapps/hphi/hphivars.sh`
     - `HPhi --version`
 
+On **macOS** (verified on recent macOS by CI), install and link `tools/gcc-wrapper` and `source $HOME/materiapps/env.sh` before building applications, so the builds use the Homebrew GCC/GFortran instead of Apple clang. See the macOS tutorial in the [manual](https://wistaria.github.io/MateriAppsInstaller/manual/master/en/index.html) for details.
+
 # License and Copyright
 
 The University of Tokyo holds the copyright of MateriApps Installer, and it is distributed under the GNU General Public License version 3 (GPL v3). The patch files for each installed software are subject to the license of the respective software.

--- a/docs/sphinx/en/source/how_to_use/index.rst
+++ b/docs/sphinx/en/source/how_to_use/index.rst
@@ -98,9 +98,9 @@ Files marked with * indicate files that always exist in the directory.
 
     - A directory containing the manual and its source code
 
-  - macosx directory
+  - macos directory
 
-    - A directory containing scripts to install the necessary tools using Macports
+    - A directory containing scripts to install the necessary tools using MacPorts
 
   - scripts directory
 

--- a/docs/sphinx/en/source/how_to_use/index.rst
+++ b/docs/sphinx/en/source/how_to_use/index.rst
@@ -27,16 +27,16 @@ Directory Structure
 
   .. code-block:: bash
 
-          |─ setup
-          |─ apps
-          |─ docs
-          |─ tools
-          |─ check_prefix.sh
-          |─ macosx
-          |   |─ install.sh
-          |   |─ ports.sh
           |- README.md
-          |- util.sh
+          |─ apps
+          |─ check_prefix.sh
+          |─ docs
+          |─ macos
+          |   |─ ports.sh
+          |─ misc
+          |─ scripts
+          |─ setup
+          |─ tools
 
 
 - The directory structure in setup, tools, and apps is given as follows.

--- a/docs/sphinx/en/source/tutorial/review1.rst
+++ b/docs/sphinx/en/source/tutorial/review1.rst
@@ -1,7 +1,9 @@
-Installation to MacOS 10.15 (Catalina)
+Installation to macOS
 ------------------------------------------------------------
 
-This section describes how to use the MateriApps Installer on MacOS 10.15 (Catalina).
+This section describes how to use the MateriApps Installer on macOS. The
+procedure is verified on recent macOS (both Apple Silicon and Intel) by the
+project's continuous integration (see the ``macos`` workflow).
 
 Installing Tools
 ****************************
@@ -54,9 +56,18 @@ Go to the MateriAppsInstaller directory, and run the following command. ::
 
 $ sh setup/setup.sh
 
-Next, enter the directory of the application you want to install and run the following command to install it. ::
+On macOS, install and link the GCC wrapper so that the application builds use
+the Homebrew GCC/GFortran (``brew install gcc`` above) instead of Apple clang,
+which cannot build most of the applications. ::
 
-$ CC=gcc-10 FC=gfortran-10 CPP=cpp-10 sh install.sh
+$ (cd tools/gcc-wrapper && sh install.sh && sh link.sh)
+$ source $HOME/materiapps/env.sh
+
+Next, enter the directory of the application you want to install and run the
+following command to install it. With the GCC wrapper set up, you no longer
+need to pass the compilers explicitly. ::
+
+$ sh install.sh
 
 You can check whether it is installed correctly by executing the following command in the directory of each application. ::
 

--- a/docs/sphinx/en/source/tutorial/review1.rst
+++ b/docs/sphinx/en/source/tutorial/review1.rst
@@ -56,9 +56,10 @@ Go to the MateriAppsInstaller directory, and run the following command. ::
 
 $ sh setup/setup.sh
 
-On macOS, install and link the GCC wrapper so that the application builds use
-the Homebrew GCC/GFortran (``brew install gcc`` above) instead of Apple clang,
-which cannot build most of the applications. ::
+On macOS, set up the GCC wrapper once, before installing any application, so
+that the application builds use the Homebrew GCC/GFortran (this requires
+``brew install gcc`` from the tool list above) instead of Apple clang, which
+cannot build most of the applications. ::
 
 $ (cd tools/gcc-wrapper && sh install.sh && sh link.sh)
 $ source $HOME/materiapps/env.sh

--- a/docs/sphinx/ja/source/how_to_use/index.rst
+++ b/docs/sphinx/ja/source/how_to_use/index.rst
@@ -32,6 +32,8 @@
 		  |─ check_prefix.sh
 		  |─ docs
 		  |─ macos
+		  |   |─ ports.sh
+		  |─ misc
 		  |- scripts
 		  |─ setup
 		  |─ tools

--- a/docs/sphinx/ja/source/tutorial/review1.rst
+++ b/docs/sphinx/ja/source/tutorial/review1.rst
@@ -1,9 +1,11 @@
 
 
-macOS 10.15 (Catalina)へのインストール
+macOSへのインストール
 ------------------------------------------------------------
 
-本節では、macOS 10.15 (Catalina)でMateriApps Installerを利用する方法を記載します。
+本節では、macOSでMateriApps Installerを利用する方法を記載します。本手順は、
+プロジェクトの継続的インテグレーション（ ``macos`` ワークフロー）により、
+近年のmacOS（Apple Silicon・Intelの両方）で動作確認されています。
 
 ツールのインストール
 ****************************
@@ -56,11 +58,20 @@ MateriAppsInstallerのディレクトリにはいり、 ::
 
 $ sh setup/setup.sh
 
-を実行します。次にインストールしたいアプリのディレクトリに入り、 ::
+を実行します。macOSでは、アプリのビルドにApple clang（多くのアプリをビルド
+できない）ではなくHomebrewのGCC/GFortran（上記の ``brew install gcc`` ）を
+使わせるため、GCCラッパーをインストール・リンクします。 ::
 
-$ CC=gcc-10 CXX=g++-10 FC=gfortran-10 CPP=cpp-10 sh install.sh
+$ (cd tools/gcc-wrapper && sh install.sh && sh link.sh)
+$ source $HOME/materiapps/env.sh
 
-を実行すればインストールができるはずです。正しくインストールされているかどうかは、各アプリのディレクトリで ::
+次にインストールしたいアプリのディレクトリに入り、 ::
+
+$ sh install.sh
+
+を実行すればインストールができるはずです。GCCラッパーを設定済みであれば、
+コンパイラを明示的に指定する必要はありません。正しくインストールされているか
+どうかは、各アプリのディレクトリで ::
 
 $ sh runtest.sh
 

--- a/docs/sphinx/ja/source/tutorial/review1.rst
+++ b/docs/sphinx/ja/source/tutorial/review1.rst
@@ -58,9 +58,10 @@ MateriAppsInstallerのディレクトリにはいり、 ::
 
 $ sh setup/setup.sh
 
-を実行します。macOSでは、アプリのビルドにApple clang（多くのアプリをビルド
-できない）ではなくHomebrewのGCC/GFortran（上記の ``brew install gcc`` ）を
-使わせるため、GCCラッパーをインストール・リンクします。 ::
+を実行します。macOSでは、いずれかのアプリをインストールする前に一度だけ、
+GCCラッパーをセットアップします。これにより、アプリのビルドにApple clang
+（多くのアプリをビルドできない）ではなくHomebrewのGCC/GFortran（上記ツール
+一覧の ``brew install gcc`` が必要）を使わせます。 ::
 
 $ (cd tools/gcc-wrapper && sh install.sh && sh link.sh)
 $ source $HOME/materiapps/env.sh


### PR DESCRIPTION
## 概要

Fixes #188

PR #187（macOS CI）のレビューで判明した、macOS 向けドキュメントの実装乖離を解消します。

### 変更

1. **`tutorial/review1.rst`（en/ja）**
   - 「macOS 10.15 (Catalina)」前提の見出し・本文を「macOS」に（CI で近年の macOS = Apple Silicon/Intel 両方で検証済みと明記）
   - アプリのインストール手順を、古い明示フラグ方式 `CC=gcc-10 FC=gfortran-10 CPP=cpp-10 sh install.sh` から、現在の推奨 = **gcc-wrapper 方式**に更新: `tools/gcc-wrapper` を install/link → `source $MA_ROOT/env.sh` → 素の `sh install.sh`（#187 の CI もこの手順）
2. **`how_to_use/index.rst`（en）のディレクトリ構造図**
   - 存在しない `macosx/install.sh`・root の `util.sh` を記載し、`scripts/`・`misc/` が抜けていたのを実構成に同期。ja 図にも欠けていた `misc/`（と `macos/ports.sh`）を追加
3. **README**
   - macOS ビルドは先に gcc-wrapper のセットアップが必要である旨を追記

`macos/ports.sh`（MacPorts + python27 時代）の扱いは #185 の棚卸しで判断します。

## 検証

- `python -m sphinx -b html` を en/ja とも実行し、**review1.rst / how_to_use の警告ゼロ**（残る appendix の toctree 警告は develop 上の stale ファイル由来で #192 が解消。本 PR の対象外）

## 補足（マージ順）

README と how_to_use (en/ja) は #178 / #186 / #191 も同セクションを触るため軽微な競合の可能性があります（いずれも自明に解消可）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)