### PR TITLE
[lammps] GPU（KOKKOS/CUDA）ビルドモード追加・arch 可変（kugui A100 検証済み）

### DIFF
--- a/apps/lammps/README.md
+++ b/apps/lammps/README.md
@@ -16,3 +16,14 @@
 
  https://ma.issp.u-tokyo.ac.jp/en/app/613
 
+
+## GPU build (mode `gpu`)
+
+ `sh install.sh gpu` builds the NVIDIA GPU (KOKKOS / CUDA) version. Set the
+ target GPU architecture first via the `KOKKOS_ARCH` environment variable
+ (required, no default): e.g. `export KOKKOS_ARCH=AMPERE80` for A100. Common
+ values are `AMPERE80` (A100), `VOLTA70` (V100), `HOPPER90` (H100), `TURING75`
+ (T4), `ADA89` (RTX 40), `PASCAL60` (P100). A wrong architecture still builds
+ but fails at run time on the GPU. Requires the CUDA toolkit (`nvcc`) and a
+ CUDA-aware MPI on `PATH`. This mode needs an NVIDIA GPU and is not covered by
+ CI. Verified on ISSP kugui (A100).

--- a/apps/lammps/README_ja.md
+++ b/apps/lammps/README_ja.md
@@ -16,3 +16,13 @@
 
  https://ma.issp.u-tokyo.ac.jp/app/596
 
+
+## GPU ビルド（モード `gpu`）
+
+ `sh install.sh gpu` で NVIDIA GPU（KOKKOS / CUDA）版をビルドする。ビルド前に
+ 環境変数 `KOKKOS_ARCH` で対象 GPU アーキテクチャを指定する（必須・既定なし）:
+ 例として A100 なら `export KOKKOS_ARCH=AMPERE80`。代表値は `AMPERE80` (A100),
+ `VOLTA70` (V100), `HOPPER90` (H100), `TURING75` (T4), `ADA89` (RTX 40),
+ `PASCAL60` (P100)。誤ったアーキテクチャでもビルドは通るが GPU 実行時に失敗する。
+ CUDA ツールキット（`nvcc`）と CUDA-aware MPI が `PATH` に必要。本モードは NVIDIA
+ GPU が必要で CI 対象外。物性研 kugui（A100）で動作確認済み。

--- a/apps/lammps/config/gpu/preprocess.sh
+++ b/apps/lammps/config/gpu/preprocess.sh
@@ -7,9 +7,18 @@ set -u
 # architecture name, e.g.:
 #   AMPERE80 (A100)   VOLTA70 (V100)    HOPPER90 (H100)
 #   ADA89    (RTX 40) TURING75 (T4/RTX 20) PASCAL60 (P100)
-# See https://kokkos.org for the full list. There is no safe default because a
+# See https://kokkos.github.io/kokkos-core-wiki/get-started/configuration-guide.html
+# for the full list. There is no safe default because a
 # wrong architecture produces binaries that will not run on the GPU.
 : "${KOKKOS_ARCH:?set KOKKOS_ARCH to your GPU Kokkos arch, e.g. AMPERE80 for A100, VOLTA70 for V100, HOPPER90 for H100, TURING75, ADA89, or PASCAL60, then re-run}"
+
+# KOKKOS_ARCH becomes part of a CMake option name (-DKokkos_ARCH_<NAME>=ON), so
+# reject anything that is not a plain Kokkos arch token before it reaches cmake.
+case "$KOKKOS_ARCH" in
+  *[!A-Za-z0-9_]*)
+    echo "Error: KOKKOS_ARCH='$KOKKOS_ARCH' contains invalid characters; expected a Kokkos arch name such as AMPERE80." >&2
+    exit 1 ;;
+esac
 
 rm -rf build
 mkdir build
@@ -27,7 +36,7 @@ cmake -C../cmake/presets/all_on.cmake -C../cmake/presets/nolib.cmake \
   -DPKG_GPU=OFF -DPKG_KOKKOS=ON \
   -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_OPENMP=yes \
   -DKokkos_ARCH_${KOKKOS_ARCH}=ON \
-  -DCMAKE_CXX_COMPILER=${NVCC_WRAPPER} -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_CXX_COMPILER="${NVCC_WRAPPER}" -DCMAKE_CXX_STANDARD=17 \
   -DBUILD_SHARED_LIBS=yes \
   -DPC_FFTW3_INCLUDE_DIRS=$FFTW_ROOT/include -DPC_FFTW3_LIBRARY_DIRS=$FFTW_ROOT/lib \
   -DCMAKE_CXX_FLAGS="-DLMP_INTEL_NO_TBB ${MA_EXTRA_FLAGS}" \

--- a/apps/lammps/config/gpu/preprocess.sh
+++ b/apps/lammps/config/gpu/preprocess.sh
@@ -1,0 +1,35 @@
+set -u
+
+# GPU build via the KOKKOS package with the CUDA backend.
+#
+# KOKKOS needs the target GPU architecture at configure time (nvcc cross-compiles
+# for a specific compute capability). Set KOKKOS_ARCH to your GPU's Kokkos
+# architecture name, e.g.:
+#   AMPERE80 (A100)   VOLTA70 (V100)    HOPPER90 (H100)
+#   ADA89    (RTX 40) TURING75 (T4/RTX 20) PASCAL60 (P100)
+# See https://kokkos.org for the full list. There is no safe default because a
+# wrong architecture produces binaries that will not run on the GPU.
+: "${KOKKOS_ARCH:?set KOKKOS_ARCH to your GPU Kokkos arch, e.g. AMPERE80 for A100, VOLTA70 for V100, HOPPER90 for H100, TURING75, ADA89, or PASCAL60, then re-run}"
+
+rm -rf build
+mkdir build
+cd build
+
+# nvcc_wrapper (Kokkos' CUDA host-compiler wrapper) ships with LAMMPS and must
+# be used as the C++ compiler for the CUDA backend. nvcc and an MPI C++ compiler
+# must be on PATH (e.g. a CUDA toolkit module + a CUDA-aware MPI).
+NVCC_WRAPPER=$(cd .. && pwd)/lib/kokkos/bin/nvcc_wrapper
+
+# Same package set as the default build (all_on minus the external-library
+# packages), but GPU-accelerated through KOKKOS. The stand-alone GPU package is
+# disabled so KOKKOS is the single GPU backend.
+cmake -C../cmake/presets/all_on.cmake -C../cmake/presets/nolib.cmake \
+  -DPKG_GPU=OFF -DPKG_KOKKOS=ON \
+  -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_OPENMP=yes \
+  -DKokkos_ARCH_${KOKKOS_ARCH}=ON \
+  -DCMAKE_CXX_COMPILER=${NVCC_WRAPPER} -DCMAKE_CXX_STANDARD=17 \
+  -DBUILD_SHARED_LIBS=yes \
+  -DPC_FFTW3_INCLUDE_DIRS=$FFTW_ROOT/include -DPC_FFTW3_LIBRARY_DIRS=$FFTW_ROOT/lib \
+  -DCMAKE_CXX_FLAGS="-DLMP_INTEL_NO_TBB ${MA_EXTRA_FLAGS}" \
+  -DCMAKE_BUILD_TYPE="Release" -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  ../cmake

--- a/apps/lammps/install.sh
+++ b/apps/lammps/install.sh
@@ -32,6 +32,15 @@ if [ ! -d $CONFIG_DIR ]; then
 fi
 DEFAULT_CONFIG_DIR=$SCRIPT_DIR/config/default
 
+# Fail fast (before the download/extract) when the gpu mode is selected without
+# its required KOKKOS_ARCH, so the user does not wait for setup only to hit the
+# guard in config/gpu/preprocess.sh.
+if [ "$mode" = "gpu" ] && [ -z "${KOKKOS_ARCH:-}" ]; then
+  echo "Error: KOKKOS_ARCH is not set (required for the gpu mode)."
+  echo "Set it to your GPU Kokkos arch, e.g. AMPERE80 (A100), VOLTA70 (V100), HOPPER90 (H100)."
+  exit 1
+fi
+
 export UTIL_SH=$SCRIPT_DIR/../../scripts/util.sh
 . $UTIL_SH
 . $SCRIPT_DIR/version.sh

--- a/apps/lammps/install.sh
+++ b/apps/lammps/install.sh
@@ -8,6 +8,8 @@ export MAKE_J="${MAKE_J:-"-j1"}"
 
 # export explicitly if defined
 test -n "${CXX+defined}" && export CXX="$CXX"
+# KOKKOS GPU architecture for the "gpu" mode (e.g. AMPERE80, VOLTA70, HOPPER90)
+test -n "${KOKKOS_ARCH+defined}" && export KOKKOS_ARCH="$KOKKOS_ARCH"
 
 EOF
 . ./config.txt

--- a/docs/sphinx/en/source/appendix/README_lammps.rst
+++ b/docs/sphinx/en/source/appendix/README_lammps.rst
@@ -26,3 +26,15 @@ MateriApps URL
 --------------
 
 https://ma.issp.u-tokyo.ac.jp/en/app/613
+
+GPU build (mode ``gpu``)
+------------------------
+
+``sh install.sh gpu`` builds the NVIDIA GPU (KOKKOS / CUDA) version. Set the
+target GPU architecture first via the ``KOKKOS_ARCH`` environment variable
+(required, no default): e.g. ``export KOKKOS_ARCH=AMPERE80`` for A100. Common
+values are ``AMPERE80`` (A100), ``VOLTA70`` (V100), ``HOPPER90`` (H100),
+``TURING75`` (T4), ``ADA89`` (RTX 40), ``PASCAL60`` (P100). A wrong
+architecture still builds but fails at run time on the GPU. Requires the CUDA
+toolkit (``nvcc``) and a CUDA-aware MPI on ``PATH``. This mode needs an NVIDIA
+GPU and is not covered by CI. Verified on ISSP kugui (A100).

--- a/docs/sphinx/ja/source/appendix/README_lammps.rst
+++ b/docs/sphinx/ja/source/appendix/README_lammps.rst
@@ -20,3 +20,14 @@ MateriApps URL
 --------------
 
 https://ma.issp.u-tokyo.ac.jp/app/596
+
+GPU ビルド（モード ``gpu``）
+----------------------------
+
+``sh install.sh gpu`` で NVIDIA GPU（KOKKOS / CUDA）版をビルドする。ビルド前に
+環境変数 ``KOKKOS_ARCH`` で対象 GPU アーキテクチャを指定する（必須・既定なし）:
+例として A100 なら ``export KOKKOS_ARCH=AMPERE80``。代表値は ``AMPERE80`` (A100),
+``VOLTA70`` (V100), ``HOPPER90`` (H100), ``TURING75`` (T4), ``ADA89`` (RTX 40),
+``PASCAL60`` (P100)。誤ったアーキテクチャでもビルドは通るが GPU 実行時に失敗する。
+CUDA ツールキット（``nvcc``）と CUDA-aware MPI が ``PATH`` に必要。本モードは
+NVIDIA GPU が必要で CI 対象外。物性研 kugui（A100）で動作確認済み。


### PR DESCRIPTION
## 概要

`apps/lammps`（stable_29Aug2024_update1, CMake）に **GPU ビルドモード `config/gpu`** を追加します。KOKKOS パッケージ + CUDA バックエンドで GPU 版 `lmp` をビルドします。default と同じパッケージ集合（all_on + nolib）を GPU 加速する構成です。

## GPU arch を可変に（重要）

GPU の compute capability はマシンごとに異なるため（kugui=A100, clavius=別 arch 等）、**`KOKKOS_ARCH` を config.txt のチューナブル変数**にしました:
- `config/gpu/preprocess.sh` は `-DKokkos_ARCH_${KOKKOS_ARCH}=ON` を使用。
- **既定値は無し**（誤った arch のバイナリは GPU で動かないため、暗黙のデフォルトは危険）。未設定時は `${VAR:?...}` で即座に分かりやすく失敗し、代表値（`AMPERE80`=A100, `VOLTA70`=V100, `HOPPER90`=H100, `TURING75`, `ADA89`, `PASCAL60`）を案内。
- → **別 GPU マシンでも `KOKKOS_ARCH` を変えるだけ**で対応可能。

nvcc（CUDA toolkit）と CUDA-aware MPI が PATH 上に必要。LAMMPS 同梱の `nvcc_wrapper` を C++ コンパイラに使用。stand-alone の GPU パッケージは無効化し KOKKOS を単一の GPU バックエンドに。

## 検証（物性研 kugui, NVIDIA A100 cc80, PBS GPU ノード）

- `KOKKOS_ARCH=AMPERE80` で configure 成功（Kokkos 4.3.1, Architecture **AMPERE80**, Backends OPENMP;CUDA, CUDA 12.4）。
- KOKKOS-CUDA ビルド成功、`lmp` が `libcudart` にリンク。
- **A100 で GPU 実行**（`lmp -k on g 1 -sf kk -in bench/in.lj`）: `KOKKOS mode ... will use up to 1 GPU(s) per node`, `attributes: ... kokkos_device`, 5133 timesteps/s（exit 0）。

## 留意点

- 本モードは NVIDIA GPU + CUDA が必要なため **GitHub CI では検証不可**（既存 CPU モードの CI はそのまま）。
- kugui の計算ノードは外部ネット不可のため、`all_on` の MESONT パッケージが configure 時に行うポテンシャル DL は計算ノードで失敗する（configure はネットのあるノードで実施）。これは **default ビルドと共通の既存挙動**で GPU 固有ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)